### PR TITLE
Fixed incorrect initial noise sampling

### DIFF
--- a/logmmse/logmmse.py
+++ b/logmmse/logmmse.py
@@ -27,7 +27,7 @@ def logmmse(x, Srate, noise_frames=6, Slen=0, eta=0.15, saved_params=None):
         noise_mean = np.zeros(nFFT)
         for j in range(0, Slen*noise_frames, Slen):
             noise_mean = noise_mean + np.absolute(np.fft.fft(win * x[j:j + Slen], nFFT, axis=0))
-        noise_mu2 = noise_mean / noise_frames ** 2
+        noise_mu2 = (noise_mean / noise_frames) ** 2
     else:
         noise_mu2 = saved_params['noise_mu2']
         Xk_prev = saved_params['Xk_prev']


### PR DESCRIPTION
The precedence of the operators made the square apply to the number of frames instead of the coefficients. The square is correctly applied after the averaging in the [original matlab script](https://github.com/braindead/Noise-reduction/blob/21b714e188f1efa0a737d12c6d9f0bd942027101/logmmse.m#L55-L56). This does not make a noticeable difference when the number of initial frames is small (because the noise profile is continuously updated anyway), however it will effectively make the noise profile near 0 when it is larger.